### PR TITLE
NEVISACCESSAPP-7321: upgrade deprecated node20 GitHub Actions to node24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
 
   build_and_tag:
     name: Build and Tag
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Checkout the repository under $GITHUB_WORKSPACE
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Set Ruby version and Cache RubyGem dependencies
       - name: Cache RubyGem Dependencies
@@ -50,7 +50,7 @@ jobs:
 
       # Ensure correct Java version is installed
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -66,11 +66,4 @@ jobs:
 
       # Build the Android app
       - name: Run Fastlane
-        uses: maierj/fastlane-action@v3.1.0
-        with:
-          lane: 'main'
-          options: |
-            {
-              "host_name": "${{ env.HOST_NAME }}",
-              "custom_uri_scheme": "${{ env.CUSTOM_URI_SCHEME }}"
-            }
+        run: bundle exec fastlane main host_name:"${{ env.HOST_NAME }}" custom_uri_scheme:"${{ env.CUSTOM_URI_SCHEME }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
 
   build:
     name: Build
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Checkout the repository under $GITHUB_WORKSPACE
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Set Ruby version and Cache RubyGem dependencies
       - name: Cache RubyGem Dependencies
@@ -47,7 +47,7 @@ jobs:
 
       # Ensure correct Java version is installed
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -58,6 +58,4 @@ jobs:
 
       # Build the Android app
       - name: Run Fastlane
-        uses: maierj/fastlane-action@v3.1.0
-        with:
-          lane: 'pr'
+        run: bundle exec fastlane pr


### PR DESCRIPTION
Upgrades actions from node20 to node24 runtime to resolve
deprecation warnings after Node.js 20 reached EOL (Apr 2026).